### PR TITLE
use kaiming initialization for conv layers

### DIFF
--- a/dacapo/experiments/model.py
+++ b/dacapo/experiments/model.py
@@ -40,6 +40,13 @@ class Model(torch.nn.Module):
         )
         self.eval_activation = eval_activation
 
+        # UPDATE WEIGHT INITIALIZATION TO USE KAIMING
+        # TODO: put this somewhere better, there might be
+        # conv layers that aren't follwed by relus?
+        for _name, layer in self.named_modules():
+            if isinstance(layer, torch.nn.modules.conv._ConvNd):
+                torch.nn.init.kaiming_normal_(layer.weight, nonlinearity="relu")
+
     def forward(self, x):
         result = self.chain(x)
         if not self.training and self.eval_activation is not None:


### PR DESCRIPTION
use kaiming initialization for convolutional layers in dacapo models.
This is important for our standard UNets since the default initialization is pretty terrible when following convolutions with ReLU's.
might want to move this into individual architectures if you are playing around with non ReLU activations