### PR TITLE
use toml's in file config store

### DIFF
--- a/dacapo/store/config_store.py
+++ b/dacapo/store/config_store.py
@@ -17,6 +17,45 @@ class DuplicateNameError(Exception):
 class ConfigStore(ABC):
     """Base class for configuration stores."""
 
+    @property
+    @abstractmethod
+    def runs(self):
+        pass
+
+    @property
+    @abstractmethod
+    def datasplits(self):
+        pass
+
+    @property
+    @abstractmethod
+    def datasets(self):
+        pass
+
+    @property
+    @abstractmethod
+    def arrays(self):
+        pass
+
+    @property
+    @abstractmethod
+    def tasks(self):
+        pass
+
+    @property
+    @abstractmethod
+    def trainers(self):
+        pass
+
+    @property
+    @abstractmethod
+    def architectures(self):
+        pass
+
+    @abstractmethod
+    def delete_config(self, database, config_name: str) -> None:
+        pass
+
     @abstractmethod
     def store_run_config(self, run_config: "RunConfig") -> None:
         """Store a run config. This should also store the configs that are part
@@ -34,6 +73,9 @@ class ConfigStore(ABC):
         """Retrieve all run config names."""
         pass
 
+    def delete_run_config(self, run_name: str) -> None:
+        self.delete_config(self.runs, run_name)
+
     @abstractmethod
     def store_task_config(self, task_config: "TaskConfig") -> None:
         """Store a task config."""
@@ -48,6 +90,9 @@ class ConfigStore(ABC):
     def retrieve_task_config_names(self) -> List[str]:
         """Retrieve all task config names."""
         pass
+
+    def delete_task_config(self, task_name: str) -> None:
+        self.delete_config(self.tasks, task_name)
 
     @abstractmethod
     def store_architecture_config(
@@ -68,6 +113,9 @@ class ConfigStore(ABC):
         """Retrieve all architecture config names."""
         pass
 
+    def delete_architecture_config(self, architecture_name: str) -> None:
+        self.delete_config(self.architectures, architecture_name)
+
     @abstractmethod
     def store_trainer_config(self, trainer_config: "TrainerConfig") -> None:
         """Store a trainer config."""
@@ -82,6 +130,9 @@ class ConfigStore(ABC):
     def retrieve_trainer_config_names(self) -> List[str]:
         """Retrieve all trainer config names."""
         pass
+
+    def delete_trainer_config(self, trainer_name: str) -> None:
+        self.delete_config(self.trainers, trainer_name)
 
     @abstractmethod
     def store_datasplit_config(self, datasplit_config: "DataSplitConfig") -> None:
@@ -98,6 +149,9 @@ class ConfigStore(ABC):
         """Retrieve all datasplit names."""
         pass
 
+    def delete_datasplit_config(self, datasplit_name: str) -> None:
+        self.delete_config(self.datasplits, datasplit_name)
+
     @abstractmethod
     def store_array_config(self, array_config: "ArrayConfig") -> None:
         """Store a array config."""
@@ -112,3 +166,6 @@ class ConfigStore(ABC):
     def retrieve_array_config_names(self) -> List[str]:
         """Retrieve all array names."""
         pass
+
+    def delete_array_config(self, array_name: str) -> None:
+        self.delete_config(self.arrays, array_name)


### PR DESCRIPTION
Using toml's instead of pickled files for file based configs makes dacapo significantly easier to use since the configs can be opened, read, and created as plain text