### PR TITLE
overhaul options

### DIFF
--- a/dacapo/store/create_store.py
+++ b/dacapo/store/create_store.py
@@ -14,19 +14,15 @@ def create_config_store():
 
     options = Options.instance()
 
-    try:
-        store_type = options.type
-    except RuntimeError:
-        store_type = "files"
-    if store_type == "mongo":
+    if options.type == "mongo":
         db_host = options.mongo_db_host
         db_name = options.mongo_db_name
         return MongoConfigStore(db_host, db_name)
-    elif store_type == "files":
+    elif options.type == "files":
         store_path = Path(options.runs_base_dir).expanduser()
         return FileConfigStore(store_path / "configs")
     else:
-        raise ValueError(f"Unknown store type {store_type}")
+        raise ValueError(f"Unknown store type {options.type}")
 
 
 def create_stats_store():
@@ -34,17 +30,15 @@ def create_stats_store():
 
     options = Options.instance()
 
-    try:
-        store_type = options.type
-    except RuntimeError:
-        store_type = "mongo"
-    if store_type == "mongo":
+    if options.type == "mongo":
         db_host = options.mongo_db_host
         db_name = options.mongo_db_name
         return MongoStatsStore(db_host, db_name)
-    elif store_type == "files":
+    elif options.type == "files":
         store_path = Path(options.runs_base_dir).expanduser()
         return FileStatsStore(store_path / "stats")
+    else:
+        raise ValueError(f"Unknown store type {options.type}")
 
 
 def create_weights_store():

--- a/tests/components/test_options.py
+++ b/tests/components/test_options.py
@@ -1,0 +1,59 @@
+from dacapo import Options
+
+
+from pathlib import Path
+import textwrap
+
+
+def test_no_config():
+    # Parse the options
+    options = Options.instance()
+
+    # Check the options
+    assert isinstance(options.runs_base_dir, Path)
+    assert options.mongo_db_host is None
+    assert options.mongo_db_name is None
+
+    # Parse the options
+    options = Options.instance(
+        runs_base_dir="tmp", mongo_db_host="localhost", mongo_db_name="dacapo"
+    )
+
+    # Check the options
+    assert options.runs_base_dir == Path("tmp")
+    assert options.mongo_db_host == "localhost"
+    assert options.mongo_db_name == "dacapo"
+
+
+# we need to change the working directory because
+# dacapo looks for the config file in the working directory
+def test_local_config_file(change_working_directory):
+    # Create a config file
+    config_file = Path("dacapo.yaml")
+    config_file.write_text(
+        textwrap.dedent(
+            """
+            runs_base_dir: /tmp
+            mongo_db_host: localhost
+            mongo_db_name: dacapo
+            """
+        )
+    )
+
+    # Parse the options
+    options = Options.instance()
+
+    # Check the options
+    assert options.runs_base_dir == Path("/tmp")
+    assert options.mongo_db_host == "localhost"
+    assert options.mongo_db_name == "dacapo"
+    assert Options.config_file() == config_file
+
+    # Parse the options
+    options = Options.instance(runs_base_dir="/tmp2")
+
+    # Check the options
+    assert options.runs_base_dir == Path("/tmp2")
+    assert options.mongo_db_host == "localhost"
+    assert options.mongo_db_name == "dacapo"
+    assert Options.config_file() == config_file

--- a/tests/fixtures/db.py
+++ b/tests/fixtures/db.py
@@ -2,19 +2,20 @@ from dacapo import Options
 
 import pymongo
 import pytest
+import attr
+
+import os
+from pathlib import Path
+import yaml
 
 
 def mongo_db_available():
-    try:
-        options = Options.instance()
-        client = pymongo.MongoClient(
-            host=options.mongo_db_host, serverSelectionTimeoutMS=1000
-        )
-        Options._instance = None
-    except RuntimeError:
-        # cannot find a dacapo config file, mongodb is not available
-        Options._instance = None
-        return False
+    options = Options.instance()
+    client = pymongo.MongoClient(
+        host=options.mongo_db_host,
+        serverSelectionTimeoutMS=1000,
+        socketTimeoutMS=1000,
+    )
     try:
         client.admin.command("ping")
         return True
@@ -34,23 +35,38 @@ def mongo_db_available():
     )
 )
 def options(request, tmp_path):
-    # TODO: Clean up this fixture. Its a bit clunky to use.
-    # Maybe just write the dacapo.yaml file instead of assigning to Options._instance
-    kwargs_from_file = {}
-    if request.param == "mongo":
-        options_from_file = Options.instance()
-        kwargs_from_file.update(
-            {
-                "mongo_db_host": options_from_file.mongo_db_host,
-                "mongo_db_name": "dacapo_tests",
-            }
-        )
-    Options._instance = None
+
+    # read the options from the users config file locally
     options = Options.instance(
-        type=request.param, runs_base_dir=f"{tmp_path}", **kwargs_from_file
+        type=request.param, runs_base_dir="tests", mongo_db_name="dacapo_tests"
     )
+
+    # change to a temporary directory for this test only
+    old_dir = os.getcwd()
+    os.chdir(tmp_path)
+
+    # write the dacapo config in the current temporary directory. Now options
+    # will be read from this file instead of the users config file letting
+    # us test different configurations
+    config_file = Path("dacapo.yaml")
+    config_file.write_text(
+        yaml.safe_dump(
+            attr.asdict(
+                options,
+                value_serializer=lambda inst, field, value: (
+                    str(value) if value is not None else None
+                ),
+            )
+        )
+    )
+
+    # yield the options
     yield options
+
+    # cleanup
     if request.param == "mongo":
         client = pymongo.MongoClient(host=options.mongo_db_host)
         client.drop_database("dacapo_tests")
-    Options._instance = None
+
+    # reset working directory
+    os.chdir(old_dir)


### PR DESCRIPTION
Overhaul DaCapo options.
There were a few problems:
1) DaCapo config fields weren't defined or documented anywhere making it hard to figure out what key words to use
2) There was an over reliance on exception handling to do basic logic which could result in annoying error catching recursions
3) Defaults were not present or bad resulting in an unnecessary setup step.

Changes:
- There is now a `DaCapoConfig` attrs class that properly defines all supported key-words along with their types, defaults, and docs.
- tests have been added
- some try - catch logic has been removed and replaced with simple attribute accessing
- defaults have been added or changed

TODO:
DESIGN DECISIONS:
1) Do we want to read once and remember the values or re-read the config file whenever we need to know its content? If we read once and remember as it was before, then running in a jupyter notebook becomes annoying since you could modify the `dacapo.yaml` file and see no effect in your notebook. If we re-read every time we need anything from the config file, then we could potentially break long running cluster jobs if someone changes their `dacapo.yaml` while dacapo is running.
2) What defaults do we want? I set the defaults to use files for all data storage, and to stash all data in `~/.dacapo` if `base_runs_dir` is not defined. This means we now no longer need a `dacapo.yaml` at all to run, but `DaCapo` can store a lot of data. Do we want to let users just start running with it without making them think of where the data will be stored?