### PR TITLE
Add bind parameters to neuroglancer instantiations

### DIFF
--- a/dacapo/experiments/datasplits/datasplit.py
+++ b/dacapo/experiments/datasplits/datasplit.py
@@ -27,13 +27,17 @@ class DataSplit(ABC):
     train: List[Dataset]
     validate: Optional[List[Dataset]]
 
-    def _neuroglancer(self, embedded=False):
+    def _neuroglancer(self, embedded=False, bind_address="0.0.0.0", bind_port=0):
         """
         A method to visualize the data in Neuroglancer. It creates a Neuroglancer viewer and adds the layers of the training and validation datasets to it.
 
         Args:
             embedded : bool
                 A boolean flag to indicate if the Neuroglancer viewer is to be embedded in the notebook.
+            bind_address : str
+                Bind address for Neuroglancer webserver
+            bind_port : int
+                Bind port for Neuroglancer webserver
         Returns:
             viewer : obj
                 The Neuroglancer viewer object.
@@ -47,7 +51,7 @@ class DataSplit(ABC):
             It creates a Neuroglancer viewer and adds the layers of the training and validation datasets to it.
             Neuroglancer is a powerful tool for visualizing large-scale volumetric data.
         """
-        neuroglancer.set_server_bind_address("0.0.0.0")
+        neuroglancer.set_server_bind_address(bind_address=bind_address, bind_port=bind_port)
         viewer = neuroglancer.Viewer()
         with viewer.txn() as s:
             train_layers = {}

--- a/dacapo/experiments/run.py
+++ b/dacapo/experiments/run.py
@@ -216,9 +216,15 @@ class Run:
     def __str__(self):
         return self.name
 
-    def visualize_pipeline(self):
+    def visualize_pipeline(self, bind_address="0.0.0.0", bind_port=0):
         """
         Visualizes the pipeline for the run, including all produced arrays.
+
+        Args:
+            bind_address : str
+                Bind address for Neuroglancer webserver
+            bind_port : int
+                Bind port for Neuroglancer webserver
 
         Examples:
             >>> run.visualize_pipeline()
@@ -238,4 +244,4 @@ class Run:
                 self.task,
                 array_store.snapshot_container(self.name),
             )
-        self.trainer.visualize_pipeline()
+        self.trainer.visualize_pipeline(bind_address, bind_port)

--- a/dacapo/experiments/trainers/gunpowder_trainer.py
+++ b/dacapo/experiments/trainers/gunpowder_trainer.py
@@ -490,7 +490,18 @@ class GunpowderTrainer(Trainer):
         """
         return all([dataset.gt is not None for dataset in datasets])
 
-    def visualize_pipeline(self):
+    def visualize_pipeline(self, bind_address="0.0.0.0", bind_port=0):
+        """
+        Visualizes the pipeline for the run, including all produced arrays.
+
+        Args:
+            bind_address : str
+                Bind address for Neuroglancer webserver
+            bind_port : int
+                Bind port for Neuroglancer webserver
+        """
+
+
         if self._pipeline is None:
             raise ValueError("Pipeline not initialized!")
 
@@ -563,7 +574,7 @@ class GunpowderTrainer(Trainer):
                     ]
                 )
 
-        neuroglancer.set_server_bind_address("0.0.0.0")
+        neuroglancer.set_server_bind_address(bind_address=bind_address, bind_port=bind_port)
 
         viewer = neuroglancer.Viewer()
 

--- a/dacapo/utils/view.py
+++ b/dacapo/utils/view.py
@@ -16,7 +16,12 @@ from typing import Optional
 
 
 def get_viewer(
-    arrays: dict, width: int = 1500, height: int = 600, headless: bool = True
+    arrays: dict, 
+    width: int = 1500, 
+    height: int = 600, 
+    headless: bool = True,
+    bind_address: str = "0.0.0.0", 
+    bind_port: int = 0
 ) -> neuroglancer.Viewer | IFrame:
     """
     Creates a neuroglancer viewer to visualize arrays.
@@ -26,6 +31,8 @@ def get_viewer(
         width (int, optional): The width of the viewer window in pixels. Defaults to 1500.
         height (int, optional): The height of the viewer window in pixels. Defaults to 600.
         headless (bool, optional): If True, returns the viewer object. If False, returns an IFrame object embedding the viewer. Defaults to True.
+        bind_address (str, optional): Bind address for Neuroglancer webserver.
+        bind_port (int, optional): Bind port for Neuroglancer webserver.
     Returns:
         neuroglancer.Viewer | IFrame: The neuroglancer viewer object or an IFrame object embedding the viewer.
     Raises:
@@ -58,7 +65,7 @@ def get_viewer(
         else:
             arrays[name]["voxel_sizes"] = array.spec.voxel_size
 
-    neuroglancer.set_server_bind_address("0.0.0.0")
+    neuroglancer.set_server_bind_address(bind_address=bind_address, bind_port=bind_port)
     viewer = neuroglancer.Viewer()
     with viewer.txn() as state:
         state.showSlices = False
@@ -365,10 +372,13 @@ class NeuroglancerRunViewer:
         neuroglancer.set_server_bind_address("0.0.0.0")
         self.viewer = neuroglancer.Viewer()
 
-    def start_neuroglancer(self):
+    def start_neuroglancer(self, bind_address="0.0.0.0", bind_port=None):
         """
         Start the neuroglancer viewer.
 
+        Args:
+            bind_address (str, optional): Bind address for Neuroglancer webserver.
+            bind_port (int, optional): Bind port for Neuroglancer webserver.
         Returns:
             IFrame: The embedded viewer.
         Raises:
@@ -380,7 +390,7 @@ class NeuroglancerRunViewer:
             >>> viewer = NeuroglancerRunViewer(run)
             >>> viewer.start_neuroglancer()
         """
-        neuroglancer.set_server_bind_address("0.0.0.0")
+        neuroglancer.set_server_bind_address(bind_address=bind_address, bind_port=bind_port)
         self.viewer = neuroglancer.Viewer()
         print(f"Neuroglancer viewer: {self.viewer}")
         with self.viewer.txn() as state:


### PR DESCRIPTION
This PR just adds a `bind_address` and `bind_port` parameter to all neuroglancer instantiation calls. The parameter defaults do not change prior behavior, and specifying bind parameters is useful for me to access neuroglancer via ssh tunnels to a cluster that does not normally expose any ports/addresses.