### PR TITLE
Normalize voxel offset for Neuroglancer run viewer by voxel size

### DIFF
--- a/dacapo/utils/view.py
+++ b/dacapo/utils/view.py
@@ -340,7 +340,7 @@ class NeuroglancerRunViewer:
                 units=["nm", "nm", "nm"],
                 scales=list(ds.voxel_size),
             ),
-            voxel_offset=list(ds.roi.offset),
+            voxel_offset=list(ds.roi.offset / ds.voxel_size),
         )
         new_state = copy.deepcopy(self.viewer.state)
         if len(new_state.layers) == 1:
@@ -406,7 +406,7 @@ class NeuroglancerRunViewer:
                         units=["nm", "nm", "nm"],
                         scales=self.raw.voxel_size,
                     ),
-                    voxel_offset=self.raw.roi.offset,
+                    voxel_offset=list(self.raw.roi.offset / self.raw.voxel_size),
                 ),
             )
         if self.embedded:


### PR DESCRIPTION
Previously the voxel offsets for the raw data and prediction labels in NeuroglancerRunViewer were in physical nanometer units instead of voxel units - and for me this produced volumes in neuroglancer that were totally offset from one another. 

This PR normalizes the voxel offsets back to voxel space so that raw and label volumes are aligned