### PR TITLE
Basic tutorial

### DIFF
--- a/dacapo/experiments/tasks/post_processors/watershed_post_processor.py
+++ b/dacapo/experiments/tasks/post_processors/watershed_post_processor.py
@@ -132,7 +132,7 @@ class WatershedPostProcessor(PostProcessor):
             self.prediction_array_identifier.dataset,
         )
 
-        data = to_ndarray(input_array, output_array.roi)
+        data = to_ndarray(input_array, output_array.roi).astype(float)
         segmentation = mws.agglom(
             data - parameters.bias, offsets=self.offsets, randomized_strides=True
         )

--- a/dacapo/predict_local.py
+++ b/dacapo/predict_local.py
@@ -57,7 +57,7 @@ def predict(
         output_roi,
         num_channels,
         output_voxel_size,
-        np.uint8,
+        np.float32,
     )
 
     logger.info("Total input ROI: %s, output ROI: %s", input_size, output_roi)
@@ -82,9 +82,6 @@ def predict(
                 .cpu()
                 .numpy()[0]
             )
-            predictions = (predictions + 1) * 255.0 / 2.0
-            predictions[predictions > 254] = 0
-            predictions = np.round(predictions).astype(np.uint8)
 
             save_ndarray(predictions, block.write_roi, result_dataset)
             # result_dataset[block.write_roi] = predictions


### PR DESCRIPTION
add some improvements to DaCapo and the basic tutorial for learning instance segmentation through affs + watershed

DaCapo:
1) avoid doing any special postprocessing to convert to uint8 when writing out the predictions. just store as float32
2) avoid converting back to float in the watershed postprocessor, just use the predictions as saved in the zarr.

Tutorial:
1) add labels colormap
2) train z affs
3) use valid padding

Loss and validation plots are included below.
There is still something strange happening with the loss after the first validation.
The results still aren't as nice as they should be on such a simple toy dataset.

![Figure_2](https://github.com/user-attachments/assets/8badb5ca-5f4b-4e8e-821b-80f13c4987eb)
![Figure_3](https://github.com/user-attachments/assets/6f7276b6-5e3b-40b1-bcdc-ba0f2b865052)
