### PR TITLE
Update gunpowder_trainer.py to swap to(device) and float()

### DIFF
--- a/dacapo/experiments/trainers/gunpowder_trainer.py
+++ b/dacapo/experiments/trainers/gunpowder_trainer.py
@@ -309,7 +309,7 @@ class GunpowderTrainer(Trainer):
                 param.grad = None
 
             t_start_prediction = time.time()
-            predicted = model.forward(torch.as_tensor(raw[raw.roi]).to(device).float())
+            predicted = model.forward(torch.as_tensor(raw[raw.roi]).float().to(device))
             predicted.retain_grad()
             loss = self._loss.compute(
                 predicted,


### PR DESCRIPTION
One more place where you have to(device) and then float().
numpy default float is 64, so the to(device) will fail if the device is MPS that doesn't support float64.