### PR TITLE
OME metadata support

### DIFF
--- a/dacapo/experiments/datasplits/datasets/arrays/zarr_array_config.py
+++ b/dacapo/experiments/datasplits/datasets/arrays/zarr_array_config.py
@@ -3,7 +3,7 @@ import attr
 from .array_config import ArrayConfig
 
 from funlib.geometry import Coordinate
-from funlib.persistence import open_ds
+from funlib.persistence import open_ds, open_ome_ds
 
 from upath import UPath as Path
 
@@ -56,9 +56,15 @@ class ZarrArrayConfig(ArrayConfig):
     mode: Optional[str] = attr.ib(
         default="a", metadata={"help_text": "The access mode!"}
     )
+    ome_metadata: bool = attr.ib(
+        default=False, metadata={"help_text": "Whether to expect OME metadata"}
+    )
 
     def array(self, mode="r"):
-        return open_ds(f"{self.file_name}/{self.dataset}", mode=mode)
+        if self.ome_metadata:
+            return open_ome_ds(f"{self.file_name}/{self.dataset}", mode=mode)
+        else:
+            return open_ds(f"{self.file_name}/{self.dataset}", mode=mode)
 
     def verify(self) -> Tuple[bool, str]:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ dependencies = [
         "funlib.geometry>=0.2",
         "mwatershed>=0.5.2",
         "cellmap-models",
-        "funlib.persistence>=0.5.3",
         "gunpowder>=1.4",
         "lsds",
         "xarray",
@@ -59,6 +58,7 @@ dependencies = [
         "upath",
         "boto3",
         "matplotlib",
+        "funlib.persistence @ git+https://github.com/funkelab/funlib.persistence.git@ome-ngff"
         ]
 
 # extras


### PR DESCRIPTION
Add ome metadata support

Needs some testing. OME zarr support is not very robust and I couldn't find a library that covered all our needs.
- There is the official ome-zarr-py package: https://github.com/ome/ome-zarr-py. I had difficulty extracting the metadata from arrays and it seems like you end up having to write your own internal models for the metadata or simply operate on the json level. See [this example](https://ome-zarr.readthedocs.io/en/stable/python.html#rendering-settings)
- Davis has a [metadata package](https://github.com/janeliascicomp/pydantic-ome-ngff) that has a lot of what I want on the metadata side, but it doesn't seem to come with much actual data support for reading and writing arrays with the given metadata.
- Davis seems to also have a [new package](https://github.com/BioImageTools/ome-zarr-models-py) that looks very promising but seems very early in development.
- Ziwen has put a lot of effort into [this library](https://github.com/czbiohub-sf/iohub) which is what I ended up going for since it seems to be the closest to fully covering both the metadata model side and tying it to actual data with something like an `open_ome_zarr` convenience function. There was only a small piece missing that I felt I needed so I opened a pull request [here](https://github.com/czbiohub-sf/iohub/pull/264) which is currently in progress.

There seem to be more implementations, but these are the ones I looked into
