### PR TITLE
fix metadata for simple zarr

### DIFF
--- a/tests/fixtures/arrays.py
+++ b/tests/fixtures/arrays.py
@@ -60,7 +60,7 @@ def cellmap_array(tmp_path):
 
     yield cellmap_array_config
 
-    
+
 @pytest.fixture()
 def multiscale_zarr(tmp_path):
     zarr_metadata = {
@@ -73,20 +73,20 @@ def multiscale_zarr(tmp_path):
                 ],
                 "coordinateTransformations": [],
                 "datasets": [
-                        {
+                    {
                         "coordinateTransformations": [
-                            {"scale": [4.2,7.4,5.6], "type": "scale"},
-                            {"translation": [6.0,10.0,2.0],"type": "translation"}
+                            {"scale": [4.2, 7.4, 5.6], "type": "scale"},
+                            {"translation": [6.0, 10.0, 2.0], "type": "translation"},
                         ],
-                        "path": "s0"
-                        },
-                        {
+                        "path": "s0",
+                    },
+                    {
                         "coordinateTransformations": [
-                            {"type": "scale","scale": [1.0,2.0,4.0]},
-                            {"type": "translation","translation": [12.0, 12.0, 12.0]}
+                            {"type": "scale", "scale": [1.0, 2.0, 4.0]},
+                            {"type": "translation", "translation": [12.0, 12.0, 12.0]},
                         ],
-                        "path": "s1"
-                        }
+                        "path": "s1",
+                    },
                 ],
                 "name": "multiscale_dataset",
                 "version": "0.4",
@@ -104,15 +104,17 @@ def multiscale_zarr(tmp_path):
         dataset="multiscale_dataset/s1",
         ome_metadata=True,
     )
-    
-    store = zarr.DirectoryStore(ome_zarr_array_config.file_name)
-    multiscale_group = zarr.group(store=store, path="multiscale_dataset", overwrite=True)
 
-    for level in [0,1]:
+    store = zarr.DirectoryStore(ome_zarr_array_config.file_name)
+    multiscale_group = zarr.group(
+        store=store, path="multiscale_dataset", overwrite=True
+    )
+
+    for level in [0, 1]:
         scaling = pow(2, level)
         multiscale_group.require_dataset(
-            name=f's{level}',
-            shape=(100/scaling, 80/scaling, 60/scaling),
+            name=f"s{level}",
+            shape=(100 / scaling, 80 / scaling, 60 / scaling),
             chunks=10,
             dtype=np.float32,
             compressor=Zstd(level=6),

--- a/tests/fixtures/arrays.py
+++ b/tests/fixtures/arrays.py
@@ -27,7 +27,7 @@ def zarr_array(tmp_path):
         zarr_array_config.dataset, data=np.zeros((100, 50, 25), dtype=np.float32)
     )
     dataset.attrs["offset"] = (12, 12, 12)
-    dataset.attrs["resolution"] = (1, 2, 4)
+    dataset.attrs["voxel_size"] = (1, 2, 4)
     dataset.attrs["axis_names"] = ["z", "y", "x"]
     yield zarr_array_config
 
@@ -45,7 +45,7 @@ def cellmap_array(tmp_path):
         data=np.arange(0, 100, dtype=np.uint8).reshape(10, 5, 2),
     )
     dataset.attrs["offset"] = (12, 12, 12)
-    dataset.attrs["resolution"] = (1, 2, 4)
+    dataset.attrs["voxel_size"] = (1, 2, 4)
     dataset.attrs["axis_names"] = ["z", "y", "x"]
 
     cellmap_array_config = BinarizeArrayConfig(

--- a/tests/fixtures/arrays.py
+++ b/tests/fixtures/arrays.py
@@ -91,7 +91,12 @@ def multiscale_zarr(tmp_path):
                 "name": "multiscale_dataset",
                 "version": "0.4",
             }
-        ]
+        ],
+        "omero": {
+            "id": 1,
+            "name": "test_image",
+            "channels": [],
+        },
     }
     ome_zarr_array_config = ZarrArrayConfig(
         name="ome_zarr_array",


### PR DESCRIPTION
Thanks for this test. I found a couple problems:
1) `funlib.persistence` uses `voxel_size` instead of `resolution` by default. (fixed)
2) The `funlib.persistence` `open_ome_ds` function had a bug in it resulting in an "Attribute does not exist" error (fixed)
3) The metadata provided in the test is apparently invalid. `iohub` throws this error: "WARNING  root:ngff.py:291 Zarr group at  does not have valid metadata for <class 'iohub.ngff.Position'>". ( not yet fixed )

Probably not worth doing for the test, but this can be configured in multiple ways (using python function `set_default_metadata_format` from `funlib.persistence.arrays.metadata`, or using config files. One of :
```
LOCAL_PATHS = [Path("pyproject.toml"), Path("funlib_persistence.toml")]
USER_PATHS = [
    Path.home() / ".config" / "funlib_persistence" / "funlib_persistence.toml"
]
GLOBAL_PATHS = [Path("/etc/funlib_persistence/funlib_persistence.toml")]
```