### PR TITLE
Python dependency fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
         "numpy>=1.22.4",
         "pyyaml",
         "zarr",
-        "cattrs",
+        "cattrs == 24.1.3",
         "pymongo",
         "tqdm",
         "simpleitk",
@@ -48,7 +48,7 @@ dependencies = [
         "cellmap-models",
         "gunpowder>=1.4",
         "lsds",
-        "xarray",
+        "xarray == 2025.1.2",
         "cattrs",
         "numpy-indexed",
         "click",
@@ -58,7 +58,7 @@ dependencies = [
         "boto3==1.35.81",
         "funlib.persistence",
         "xarray-multiscale",
-        "bioimageio.core[pytorch] >= 0.7",
+        "bioimageio.core[pytorch] == 0.7",
         ]
 
 # extras

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
         "scipy",
         "upath",
         "boto3==1.35.81",
-        "funlib.persistence @ git+https://github.com/funkelab/funlib.persistence.git@ome-ngff",
+        "funlib.persistence",
         "xarray-multiscale",
         "bioimageio.core[pytorch] >= 0.7",
         ]


### PR DESCRIPTION
Running the latest main branch fails because of deprecated functions/objects in packages. This change reverts several packages, and with this I'm able to complete a local training run (some other issues I've had to fix which I'll submit separate PRs for later).

- `cattrs` - reverted to avoid registering `Path` from the `upath` module
- `xarray` reverted to restore `ops` module
- `funlib.persistence` reverted to latest release, prior referenced branch was merged
- `bioimageio.core[pytorch]` frozen to 0.7 to preserve pytorch converter

May be more changes necessary to dependencies that could be necessary in the future. Maybe we should freeze other dependencies here to avoid issues in the future. Happy to share my conda package list 