### PR TITLE
fix: restore DataSplitGenerator, fix broken logger calls, promote HotDistance config params

### DIFF
--- a/dacapo/experiments/datasplits/__init__.py
+++ b/dacapo/experiments/datasplits/__init__.py
@@ -5,3 +5,4 @@ from .dummy_datasplit_config import DummyDataSplitConfig
 from .train_validate_datasplit import TrainValidateDataSplit
 from .train_validate_datasplit_config import TrainValidateDataSplitConfig
 from .simple_config import SimpleDataSplitConfig
+from .datasplit_generator import DataSplitGenerator

--- a/dacapo/experiments/datasplits/datasplit_generator.py
+++ b/dacapo/experiments/datasplits/datasplit_generator.py
@@ -1,0 +1,1088 @@
+from dacapo.experiments.tasks import TaskConfig
+from dacapo.experiments.datasplits.datasets.arrays import ArrayConfig
+from upath import UPath as Path
+from typing import List, Union, Optional, Sequence
+from enum import Enum, EnumMeta
+from funlib.geometry import Coordinate
+
+import zarr
+from zarr.n5 import N5FSStore
+import numpy as np
+from dacapo.experiments.datasplits.datasets.arrays import (
+    ResampledArrayConfig,
+    BinarizeArrayConfig,
+    IntensitiesArrayConfig,
+    ConcatArrayConfig,
+    LogicalOrArrayConfig,
+    ConstantArrayConfig,
+    CropArrayConfig,
+    ZarrArrayConfig,
+)
+from dacapo.experiments.datasplits.train_validate_datasplit_config import (
+    TrainValidateDataSplitConfig,
+)
+from dacapo.experiments.datasplits.datasets import RawGTDatasetConfig
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def is_zarr_group(file_name: Path, dataset: str):
+    """
+    Check if the dataset is a Zarr group. If the dataset is a Zarr group, it will return True, otherwise False.
+
+    Args:
+        file_name : str
+            The name of the file.
+        dataset : str
+            The name of the dataset.
+    Returns:
+        bool : True if the dataset is a Zarr group, otherwise False.
+    Raises:
+        FileNotFoundError
+            If the file does not exist, a FileNotFoundError is raised.
+    Examples:
+        >>> is_zarr_group(file_name, dataset)
+    Notes:
+        This function is used to check if the dataset is a Zarr group.
+    """
+    if file_name.suffix == ".n5":
+        zarr_file = zarr.open(N5FSStore(str(file_name)), mode="r")
+    else:
+        zarr_file = zarr.open(str(file_name), mode="r")
+    return isinstance(zarr_file[dataset], zarr.hierarchy.Group)
+
+
+def resize_if_needed(
+    array_config: ZarrArrayConfig, target_resolution: Coordinate, extra_str=""
+):
+    """
+    Resize the array if needed. If the array needs to be resized, it will return the resized array, otherwise it will return the original array.
+
+    Args:
+        array_config : obj
+            The configuration of the array.
+        target_resolution : obj
+            The target resolution.
+        extra_str : str
+            An extra string.
+    Returns:
+        obj : The resized array if needed, otherwise the original array.
+    Raises:
+        FileNotFoundError
+            If the file does not exist, a FileNotFoundError is raised.
+    Examples:
+        >>> resize_if_needed(array_config, target_resolution, extra_str)
+    Notes:
+        This function is used to resize the array if needed.
+    """
+    zarr_array = array_config.array()
+    raw_voxel_size = zarr_array.voxel_size
+
+    raw_upsample = raw_voxel_size / target_resolution
+    raw_downsample = target_resolution / raw_voxel_size
+    assert len(target_resolution) == zarr_array.dims, (
+        f"Target resolution {target_resolution} and raw voxel size {raw_voxel_size} "
+        f"have different dimensions {zarr_array.dims}"
+    )
+    if any([u > 1 or d > 1 for u, d in zip(raw_upsample, raw_downsample)]):
+        logger.info(
+            f"dataset {array_config} needs resampling to {target_resolution}, upsample: {raw_upsample}, downsample: {raw_downsample}"
+        )
+        return ResampledArrayConfig(
+            name=f"{extra_str}_{array_config.name}_{array_config.dataset}_resampled",
+            source_array_config=array_config,
+            upsample=raw_upsample,
+            downsample=raw_downsample,
+            interp_order=False,
+        )
+    else:
+        return array_config
+
+
+def limit_validation_crop_size(gt_config, mask_config, max_size):
+    gt_array = gt_config.array()
+    voxel_shape = gt_array.roi.shape / gt_array.voxel_size
+    crop = False
+    while np.prod(voxel_shape) > max_size:
+        crop = True
+        max_idx = np.argmax(voxel_shape)
+        voxel_shape = Coordinate(
+            s if i != max_idx else s // 2 for i, s in enumerate(voxel_shape)
+        )
+    if crop:
+        crop_roi_shape = voxel_shape * gt_array.voxel_size
+        context = (gt_array.roi.shape - crop_roi_shape) / 2
+        crop_roi = gt_array.roi.grow(-context, -context)
+        crop_roi = crop_roi.snap_to_grid(gt_array.voxel_size, mode="shrink")
+
+        logger.debug(
+            f"Cropped {gt_config.name}: original roi: {gt_array.roi}, new_roi: {crop_roi}"
+        )
+
+        gt_config = CropArrayConfig(
+            name=gt_config.name + "_cropped",
+            source_array_config=gt_config,
+            roi=crop_roi,
+        )
+        mask_config = CropArrayConfig(
+            name=mask_config.name + "_cropped",
+            source_array_config=gt_config,
+            roi=crop_roi,
+        )
+    return gt_config, mask_config
+
+
+def get_right_resolution_array_config(
+    container: Path, dataset, target_resolution, extra_str=""
+):
+    """
+    Get the right resolution array configuration. It will return the right resolution array configuration.
+
+    Args:
+        container : obj
+            The container.
+        dataset : str
+            The dataset.
+        target_resolution : obj
+            The target resolution.
+        extra_str : str
+            An extra string.
+    Returns:
+        obj : The right resolution array configuration.
+    Raises:
+        FileNotFoundError
+            If the file does not exist, a FileNotFoundError is raised.
+    Examples:
+        >>> get_right_resolution_array_config(container, dataset, target_resolution, extra_str)
+    Notes:
+        This function is used to get the right resolution array configuration.
+    """
+    level = 0
+    current_dataset_path = Path(dataset, f"s{level}")
+    if not (container / current_dataset_path).exists():
+        raise FileNotFoundError(
+            f"Path {container} is a Zarr Group and /s0 does not exist."
+        )
+
+    zarr_config = ZarrArrayConfig(
+        name=f"{extra_str}_{container.stem}_{dataset}_uint8",
+        file_name=container,
+        dataset=str(current_dataset_path),
+        snap_to_grid=target_resolution,
+        mode="r",
+    )
+    zarr_array = zarr_config.array()
+    while (
+        all([z < t for (z, t) in zip(zarr_array.voxel_size, target_resolution)])
+        and Path(container, Path(dataset, f"s{level+1}")).exists()
+    ):
+        level += 1
+        zarr_config = ZarrArrayConfig(
+            name=f"{extra_str}_{container.stem}_{dataset}_s{level}_uint8",
+            file_name=container,
+            dataset=str(Path(dataset, f"s{level}")),
+            snap_to_grid=target_resolution,
+            mode="r",
+        )
+
+        zarr_array = zarr_config.array()
+    return resize_if_needed(zarr_config, target_resolution, extra_str)
+
+
+class CustomEnumMeta(EnumMeta):
+    """
+    Custom Enum Meta class to raise KeyError when an invalid option is passed.
+
+    Attributes:
+        _member_names_ : list
+            The list of member names.
+    Methods:
+        __getitem__(self, item)
+            A method to get the item.
+    Notes:
+        This class is used to raise KeyError when an invalid option is passed.
+    """
+
+    def __getitem__(self, item):
+        """
+        Get the item.
+
+        Args:
+            item : obj
+                The item.
+        Returns:
+            obj : The item.
+        Raises:
+            KeyError
+            If the item is not a valid option, a KeyError is raised.
+        Examples:
+            >>> __getitem__(item)
+        Notes:
+            This function is used to get the item.
+        """
+        if item not in self._member_names_:
+            raise KeyError(
+                f"{item} is not a valid option of {self.__name__}, the valid options are {self._member_names_}"
+            )
+        return super().__getitem__(item)
+
+
+class CustomEnum(Enum, metaclass=CustomEnumMeta):
+    """
+    A custom Enum class to raise KeyError when an invalid option is passed.
+
+    Attributes:
+        __str__ : str
+            The string representation of the class.
+    Methods:
+        __str__(self)
+            A method to get the string representation of the class.
+    Notes:
+        This class is used to raise KeyError when an invalid option is passed.
+    """
+
+    def __str__(self) -> str:
+        """
+        Get the string representation of the class.
+
+        Args:
+            self : obj
+                The object.
+        Returns:
+            str : The string representation of the class.
+        Raises:
+            KeyError
+            If the item is not a valid option, a KeyError is raised.
+        Examples:
+            >>> __str__()
+        Notes:
+            This function is used to get the string representation of the class.
+        """
+        return self.name
+
+
+class DatasetType(CustomEnum):
+    """
+    An Enum class to represent the dataset type. It is derived from `CustomEnum` class.
+
+    Attributes:
+        val : int
+            The value of the dataset type.
+        train : int
+            The training dataset type.
+    Methods:
+        __str__(self)
+            A method to get the string representation of the class.
+    Notes:
+        This class is used to represent the dataset type.
+    """
+
+    val = 1
+    train = 2
+
+
+class SegmentationType(CustomEnum):
+    """
+    An Enum class to represent the segmentation type. It is derived from `CustomEnum` class.
+
+    Attributes:
+        semantic : int
+            The semantic segmentation type.
+        instance : int
+            The instance segmentation type.
+    Methods:
+        __str__(self)
+            A method to get the string representation of the class.
+    Notes:
+        This class is used to represent the segmentation type.
+    """
+
+    semantic = 1
+    instance = 2
+
+
+class DatasetSpec:
+    """
+    A class for dataset specification. It is used to specify the dataset.
+
+    Attributes:
+        dataset_type : obj
+            The dataset type.
+        raw_container : obj
+            The raw container.
+        raw_dataset : str
+            The raw dataset.
+        gt_container : obj
+            The ground truth container.
+        gt_dataset : str
+            The ground truth dataset.
+    Methods:
+        __init__(dataset_type, raw_container, raw_dataset, gt_container, gt_dataset)
+            Initializes the DatasetSpec class with the specified dataset type, raw container, raw dataset, ground truth container, and ground truth dataset.
+        __str__(self)
+            A method to get the string representation of the class.
+    Notes:
+        This class is used to specify the dataset.
+    """
+
+    def __init__(
+        self,
+        dataset_type: Union[str, DatasetType],
+        raw_container: Union[str, Path],
+        raw_dataset: str,
+        gt_container: Union[str, Path],
+        gt_dataset: str,
+    ):
+        """
+        Initializes the DatasetSpec class with the specified dataset type, raw container, raw dataset, ground truth container, and ground truth dataset.
+
+        Args:
+            dataset_type : obj
+                The dataset type.
+            raw_container : obj
+                The raw container.
+            raw_dataset : str
+                The raw dataset.
+            gt_container : obj
+                The ground truth container.
+            gt_dataset : str
+                The ground truth dataset.
+        Raises:
+            KeyError
+            If the item is not a valid option, a KeyError is raised.
+        Methods:
+            __init__(dataset_type, raw_container, raw_dataset, gt_container, gt_dataset)
+        Notes:
+            This function is used to initialize the DatasetSpec class with the specified dataset type, raw container, raw dataset, ground truth container, and ground truth dataset.
+        """
+        if isinstance(dataset_type, str):
+            dataset_type = DatasetType[dataset_type.lower()]
+
+        if isinstance(raw_container, str):
+            raw_container = Path(raw_container)
+
+        if isinstance(gt_container, str):
+            gt_container = Path(gt_container)
+
+        self.dataset_type = dataset_type
+        self.raw_container = raw_container
+        self.raw_dataset = raw_dataset
+        self.gt_container = gt_container
+        self.gt_dataset = gt_dataset
+
+    def __str__(self) -> str:
+        """
+        Get the string representation of the class.
+
+        Args:
+            self : obj
+                The object.
+        Returns:
+            str : The string representation of the class.
+        Raises:
+            KeyError
+            If the item is not a valid option, a KeyError is raised.
+        Examples:
+            >>> __str__()
+        Notes:
+            This function is used to get the string representation of the class.
+        """
+        return f"{self.raw_container.stem}_{self.gt_dataset}"
+
+
+def generate_dataspec_from_csv(csv_path: Path):
+    """
+    Generate the dataset specification from the CSV file. It will return the dataset specification.
+
+    Args:
+        csv_path : obj
+            The CSV file path.
+    Returns:
+        list : The dataset specification.
+    Raises:
+        FileNotFoundError
+            If the file does not exist, a FileNotFoundError is raised.
+    Examples:
+        >>> generate_dataspec_from_csv(csv_path)
+    Notes:
+        This function is used to generate the dataset specification from the CSV file.
+    """
+    datasets = []
+    if not csv_path.exists():
+        raise FileNotFoundError(f"CSV file {csv_path} does not exist.")
+    with open(csv_path, "r") as f:
+        for line in f:
+            (
+                dataset_type,
+                raw_container,
+                raw_dataset,
+                gt_container,
+                gt_dataset,
+            ) = line.strip().split(",")
+            datasets.append(
+                DatasetSpec(
+                    dataset_type=DatasetType[dataset_type.lower()],
+                    raw_container=Path(raw_container),
+                    raw_dataset=raw_dataset,
+                    gt_container=Path(gt_container),
+                    gt_dataset=gt_dataset,
+                )
+            )
+
+    return datasets
+
+
+def _validate_resolution(resolution: Sequence, name: str) -> Coordinate:
+    """
+    Validate and convert a resolution sequence to a Coordinate of integers.
+
+    Funlib's Coordinate class only supports integer values. If non-integer
+    values are provided, they are silently truncated, which can cause ROI
+    desync issues (see GitHub issue #296). This function warns the user
+    when truncation will occur so they can adjust their data accordingly.
+
+    Args:
+        resolution : Sequence
+            The resolution values to validate.
+        name : str
+            The parameter name, used in warning messages.
+    Returns:
+        Coordinate : The resolution as a Coordinate of integers.
+    """
+    has_non_integers = any(v != int(v) for v in resolution)
+    if has_non_integers:
+        truncated = tuple(int(v) for v in resolution)
+        logger.warning(
+            f"{name} contains non-integer values {tuple(resolution)}, which will be "
+            f"truncated to integers {truncated} by funlib.geometry.Coordinate. "
+            f"This truncation can cause ROI desync. Consider rescaling your data "
+            f"to an integer voxel size before proceeding (see GitHub issue #296)."
+        )
+    return Coordinate(resolution)
+
+
+class DataSplitGenerator:
+    """Generates DataSplitConfig for a given task config and datasets.
+
+    Class names in gt_dataset should be within [] e.g. [mito&peroxisome&er] for
+    multiple classes or [mito] for one class.
+
+    Currently only supports:
+     - semantic segmentation.
+     Supports:
+        - 2D and 3D datasets.
+        - Zarr, N5 and OME-Zarr datasets.
+        - Multi class targets.
+        - Different resolutions for raw and ground truth datasets.
+        - Different resolutions for training and validation datasets.
+
+    Attributes:
+        name : str
+            The name of the data split generator.
+        datasets : list
+            The list of dataset specifications.
+        input_resolution : obj
+            The input resolution.
+        output_resolution : obj
+            The output resolution.
+        targets : list
+            The list of targets.
+        segmentation_type : obj
+            The segmentation type.
+        max_gt_downsample : int
+            The maximum ground truth downsample.
+        max_gt_upsample : int
+            The maximum ground truth upsample.
+        max_raw_training_downsample : int
+            The maximum raw training downsample.
+        max_raw_training_upsample : int
+            The maximum raw training upsample.
+        max_raw_validation_downsample : int
+            The maximum raw validation downsample.
+        max_raw_validation_upsample : int
+            The maximum raw validation upsample.
+        min_training_volume_size : int
+            The minimum training volume size.
+        raw_min : int
+            The minimum raw value.
+        raw_max : int
+            The maximum raw value.
+        classes_separator_character : str
+            The classes separator character.
+        max_validation_volume_size : int
+            The maximum validation volume size. Default is None. If None, the validation volume size is not limited.
+            else, the validation volume size is limited to the specified value.
+            e.g. 600**3 for 600^3 voxels = 216_000_000 voxels.
+    Methods:
+        __init__(name, datasets, input_resolution, output_resolution, targets, segmentation_type, max_gt_downsample, max_gt_upsample, max_raw_training_downsample, max_raw_training_upsample, max_raw_validation_downsample, max_raw_validation_upsample, min_training_volume_size, raw_min, raw_max, classes_separator_character)
+            Initializes the DataSplitGenerator class with the specified name, datasets, input resolution, output resolution, targets, segmentation type, maximum ground truth downsample, maximum ground truth upsample, maximum raw training downsample, maximum raw training upsample, maximum raw validation downsample, maximum raw validation upsample, minimum training volume size, minimum raw value, maximum raw value, and classes separator character.
+        __str__(self)
+            A method to get the string representation of the class.
+        class_name(self)
+            A method to get the class name.
+        check_class_name(self, class_name)
+            A method to check the class name.
+        compute(self)
+            A method to compute the data split.
+        __generate_semantic_seg_datasplit(self)
+            A method to generate the semantic segmentation data split.
+        __generate_semantic_seg_dataset_crop(self, dataset)
+            A method to generate the semantic segmentation dataset crop.
+        generate_csv(datasets, csv_path)
+            A method to generate the CSV file.
+        generate_from_csv(csv_path, input_resolution, output_resolution, name, **kwargs)
+            A method to generate the data split from the CSV file.
+    Notes:
+        - This class is used to generate the DataSplitConfig for a given task config and datasets.
+        - Class names in gt_dataset shoulb be within [] e.g. [mito&peroxisome&er] for mutiple classes or [mito] for one class
+    """
+
+    def __init__(
+        self,
+        name: str,
+        datasets: List[DatasetSpec],
+        input_resolution: Union[Sequence[int], Coordinate],
+        output_resolution: Union[Sequence[int], Coordinate],
+        targets: Optional[List[str]] = None,
+        segmentation_type: Union[str, SegmentationType] = "semantic",
+        max_gt_downsample=32,
+        max_gt_upsample=4,
+        max_raw_training_downsample=16,
+        max_raw_training_upsample=2,
+        max_raw_validation_downsample=8,
+        max_raw_validation_upsample=2,
+        min_training_volume_size=8_000,  # 20**3
+        raw_min=0,
+        raw_max=255,
+        classes_separator_character="&",
+        use_negative_class=False,
+        max_validation_volume_size=None,
+        binarize_gt=False,
+    ):
+        """
+        Initializes the DataSplitGenerator class with the specified:
+        - name
+        - datasets
+        - input resolution
+        - output resolution
+        - targets
+        - segmentation type
+        - maximum ground truth downsample
+        - maximum ground truth upsample
+        - maximum raw training downsample
+        - maximum raw training upsample
+        - maximum raw validation downsample
+        - maximum raw validation upsample
+        - minimum training volume size
+        - minimum raw value
+        - maximum raw value
+        - classes separator character
+        - use negative class
+        - binarize ground truth
+
+        Args:
+            name : str
+                The name of the data split generator.
+            datasets : list
+                The list of dataset specifications.
+            input_resolution : obj
+                The input resolution. Must contain integer values; non-integer
+                values will be truncated with a warning (see GitHub issue #296).
+            output_resolution : obj
+                The output resolution. Must contain integer values; non-integer
+                values will be truncated with a warning (see GitHub issue #296).
+            targets : list
+                The list of targets.
+            segmentation_type : obj
+                The segmentation type.
+            max_gt_downsample : int
+                The maximum ground truth downsample.
+            max_gt_upsample : int
+                The maximum ground truth upsample.
+            max_raw_training_downsample : int
+                The maximum raw training downsample.
+            max_raw_training_upsample : int
+                The maximum raw training upsample.
+            max_raw_validation_downsample : int
+                The maximum raw validation downsample.
+            max_raw_validation_upsample : int
+                The maximum raw validation upsample.
+            min_training_volume_size : int
+                The minimum training volume size.
+            raw_min : int
+                The minimum raw value.
+            raw_max : int
+                The maximum raw value.
+            classes_separator_character : str
+                The classes separator character.
+            use_negative_class : bool
+                Whether to use negative classes.
+            binarize_gt : bool
+                Whether to binarize the ground truth as part of preprocessing. Use this if you are doing semantic segmentation on instance labels (where each object has a unique ID).
+        Returns:
+            obj : The DataSplitGenerator class.
+        Raises:
+            ValueError
+            If the class name is already set, a ValueError is raised.
+        Examples:
+            >>> DataSplitGenerator(name, datasets, input_resolution, output_resolution, targets, segmentation_type, max_gt_downsample, max_gt_upsample, max_raw_training_downsample, max_raw_training_upsample, max_raw_validation_downsample, max_raw_validation_upsample, min_training_volume_size, raw_min, raw_max, classes_separator_character)
+        Notes:
+            This function is used to initialize the DataSplitGenerator class with the specified name, datasets, input resolution, output resolution, targets, segmentation type, maximum ground truth downsample, maximum ground truth upsample, maximum raw training downsample, maximum raw training upsample, maximum raw validation downsample, maximum raw validation upsample, minimum training volume size, minimum raw value, maximum raw value, and classes separator character.
+
+        """
+        if not isinstance(input_resolution, Coordinate):
+            input_resolution = _validate_resolution(input_resolution, "input_resolution")
+        if not isinstance(output_resolution, Coordinate):
+            output_resolution = _validate_resolution(
+                output_resolution, "output_resolution"
+            )
+        if isinstance(segmentation_type, str):
+            segmentation_type = SegmentationType[segmentation_type.lower()]
+
+        self.name = name
+        self.datasets = datasets
+        self.input_resolution = input_resolution
+        self.output_resolution = output_resolution
+        self.targets = targets
+        self._class_name = None
+        self.segmentation_type = segmentation_type
+        self.max_gt_downsample = max_gt_downsample
+        self.max_gt_upsample = max_gt_upsample
+        self.max_raw_training_downsample = max_raw_training_downsample
+        self.max_raw_training_upsample = max_raw_training_upsample
+        self.max_raw_validation_downsample = max_raw_validation_downsample
+        self.max_raw_validation_upsample = max_raw_validation_upsample
+        self.min_training_volume_size = min_training_volume_size
+        self.raw_min = raw_min
+        self.raw_max = raw_max
+        self.classes_separator_character = classes_separator_character
+        self.use_negative_class = use_negative_class
+        self.max_validation_volume_size = max_validation_volume_size
+        self.binarize_gt = binarize_gt
+        if use_negative_class:
+            if targets is None:
+                raise ValueError(
+                    "use_negative_class=True requires targets to be specified."
+                )
+
+    def __str__(self) -> str:
+        """
+        Get the string representation of the class.
+
+        Args:
+            self : obj
+                The object.
+        Returns:
+            str : The string representation of the class.
+        Raises:
+            ValueError
+            If the class name is already set, a ValueError is raised.
+        Examples:
+            >>> __str__()
+        Notes:
+            This function is used to get the string representation of the class.
+        """
+        return f"DataSplitGenerator:{self.name}_{self.segmentation_type}_{self.class_name}_{self.output_resolution[0]}nm"
+
+    @property
+    def class_name(self):
+        """
+        Get the class name.
+
+        Args:
+            self : obj
+                The object.
+        Returns:
+            obj : The class name.
+        Raises:
+            ValueError
+            If the class name is already set, a ValueError is raised.
+        Examples:
+            >>> class_name
+        Notes:
+            This function is used to get the class name.
+        """
+        if self._class_name is None:
+            if self.targets is None:
+                logger.warning("Both targets and class name are None.")
+                return None
+            self._class_name = self.targets
+        return self._class_name
+
+    # Goal is to force class_name to be set only once, so we have the same classes for all datasets
+    @class_name.setter
+    def class_name(self, class_name):
+        """
+        Set the class name.
+
+        Args:
+            self : obj
+                The object.
+            class_name : obj
+                The class name.
+        Returns:
+            obj : The class name.
+        Raises:
+            ValueError
+            If the class name is already set, a ValueError is raised.
+        Examples:
+            >>> class_name
+        Notes:
+            This function is used to set the class name.
+        """
+        if self._class_name is not None:
+            raise ValueError(
+                f"Class name already set. Current class name is {self.class_name} and new class name is {class_name}"
+            )
+        self._class_name = class_name
+
+    def check_class_name(self, class_name):
+        """
+        Check the class name.
+
+        Args:
+            self : obj
+                The object.
+            class_name : obj
+                The class name.
+        Returns:
+            obj : The class name.
+        Raises:
+            ValueError
+            If the class name is already set, a ValueError is raised.
+        Examples:
+            >>> check_class_name(class_name)
+        Notes:
+            This function is used to check the class name.
+
+        """
+        datasets, classes = format_class_name(
+            class_name, self.classes_separator_character, self.targets
+        )
+        if self.class_name is None:
+            self.class_name = classes
+            if self.targets is None:
+                logger.warning(
+                    f" No targets specified, using all classes in the dataset as target {classes}."
+                )
+        elif self.class_name != classes:
+            raise ValueError(
+                f"Datasets are having different classes names:  {classes} does not match {self.class_name}"
+            )
+        return datasets, classes
+
+    def compute(self):
+        """
+        Compute the data split.
+
+        Args:
+            self : obj
+                The object.
+        Returns:
+            obj : The data split.
+        Raises:
+            NotImplementedError
+            If the segmentation type is not implemented, a NotImplementedError is raised.
+        Examples:
+            >>> compute()
+        Notes:
+            This function is used to compute the data split.
+        """
+        if self.segmentation_type == SegmentationType.semantic:
+            return self.__generate_semantic_seg_datasplit()
+        else:
+            raise NotImplementedError(
+                f"{self.segmentation_type} segmentation not implemented yet!"
+            )
+
+    def __generate_semantic_seg_datasplit(self):
+        """
+        Generate the semantic segmentation data split.
+
+        Args:
+            self : obj
+                The object.
+        Returns:
+            obj : The data split.
+        Raises:
+            FileNotFoundError
+            If the file does not exist, a FileNotFoundError is raised.
+        Examples:
+            >>> __generate_semantic_seg_datasplit()
+        Notes:
+            This function is used to generate the semantic segmentation data split.
+
+        """
+        train_dataset_configs = []
+        validation_dataset_configs = []
+        for dataset in self.datasets:
+            (
+                raw_config,
+                gt_config,
+                mask_config,
+            ) = self.__generate_semantic_seg_dataset_crop(dataset)
+            if type(self.class_name) == list:
+                classes = self.classes_separator_character.join(self.class_name)
+            else:
+                classes = self.class_name
+            if dataset.dataset_type == DatasetType.train:
+                train_dataset_configs.append(
+                    RawGTDatasetConfig(
+                        name=f"{dataset}_{gt_config.name}_{classes}_{self.output_resolution[0]}nm",
+                        raw_config=raw_config,
+                        gt_config=gt_config,
+                        mask_config=mask_config,
+                    )
+                )
+            else:
+                if self.max_validation_volume_size is not None:
+                    gt_config, mask_config = limit_validation_crop_size(
+                        gt_config, mask_config, self.max_validation_volume_size
+                    )
+                validation_dataset_configs.append(
+                    RawGTDatasetConfig(
+                        name=f"{dataset}_{gt_config.name}_{classes}_{self.output_resolution[0]}nm",
+                        raw_config=raw_config,
+                        gt_config=gt_config,
+                        mask_config=mask_config,
+                    )
+                )
+
+        return TrainValidateDataSplitConfig(
+            name=f"{self.name}_{self.segmentation_type}_{classes}_{self.output_resolution[0]}nm",
+            train_configs=train_dataset_configs,
+            validate_configs=validation_dataset_configs,
+        )
+
+    def __generate_semantic_seg_dataset_crop(self, dataset: DatasetSpec):
+        """
+        Generate the semantic segmentation dataset crop.
+
+        Args:
+            self : obj
+                The object.
+            dataset : obj
+                The dataset.
+        Returns:
+            obj : The dataset crop.
+        Raises:
+            FileNotFoundError
+            If the file does not exist, a FileNotFoundError is raised.
+        Examples:
+            >>> __generate_semantic_seg_dataset_crop(dataset)
+        Notes:
+            This function is used to generate the semantic segmentation dataset crop.
+        """
+        raw_container = dataset.raw_container
+        raw_dataset = dataset.raw_dataset
+        gt_path = dataset.gt_container
+        gt_dataset = dataset.gt_dataset
+
+        if not (raw_container / raw_dataset).exists():
+            raise FileNotFoundError(
+                f"Raw path {raw_container/raw_dataset} does not exist."
+            )
+
+        if is_zarr_group(raw_container, raw_dataset):
+            raw_config = get_right_resolution_array_config(
+                raw_container, raw_dataset, self.input_resolution, "raw"
+            )
+        else:
+            raw_config = resize_if_needed(
+                ZarrArrayConfig(
+                    name=f"raw_{raw_container.stem}_uint8",
+                    file_name=raw_container,
+                    dataset=raw_dataset,
+                    mode="r",
+                ),
+                self.input_resolution,
+                "raw",
+            )
+        raw_config = IntensitiesArrayConfig(
+            name=f"raw_{raw_container.stem}_uint8",
+            source_array_config=raw_config,
+            min=self.raw_min,
+            max=self.raw_max,
+        )
+        organelle_arrays = {}
+        classes_datasets, classes = format_class_name(
+            gt_dataset, self.classes_separator_character, self.targets
+        )
+        for current_class_dataset, current_class_name in zip(classes_datasets, classes):
+            if not (gt_path / current_class_dataset).exists():
+                raise FileNotFoundError(
+                    f"GT path {gt_path/current_class_dataset} does not exist."
+                )
+            if is_zarr_group(gt_path, current_class_dataset):
+                gt_config = get_right_resolution_array_config(
+                    gt_path, current_class_dataset, self.output_resolution, "gt"
+                )
+            else:
+                gt_config = resize_if_needed(
+                    ZarrArrayConfig(
+                        name=f"gt_{gt_path.stem}_{current_class_dataset}_uint8",
+                        file_name=gt_path,
+                        dataset=current_class_dataset,
+                        mode="r",
+                    ),
+                    self.output_resolution,
+                    "gt",
+                )
+            if self.binarize_gt:
+                gt_config = BinarizeArrayConfig(
+                    f"{dataset}_{current_class_name}_{self.output_resolution[0]}nm_binarized",
+                    source_array_config=gt_config,
+                    groupings=[(current_class_name, [])],
+                )
+            organelle_arrays[current_class_name] = gt_config
+
+        if self.targets is None:
+            targets_str = "_".join(classes)
+            current_targets = classes
+        else:
+            current_targets = self.targets
+            targets_str = "_".join(self.targets)
+
+        target_images = dict[str, ArrayConfig]()
+        target_masks = dict[str, ArrayConfig]()
+
+        missing_classes = [c for c in current_targets if c not in classes]
+        found_classes = [c for c in current_targets if c in classes]
+        for t in found_classes:
+            target_images[t] = organelle_arrays[t]
+
+        if len(missing_classes) > 0:
+            if not self.use_negative_class:
+                raise ValueError(
+                    f"Missing classes found, {str(missing_classes)}, please specify use_negative_class=True to generate the missing classes."
+                )
+            else:
+                if len(organelle_arrays) == 0:
+                    raise ValueError(
+                        f"No target classes found, please specify targets to generate the negative classes."
+                    )
+                # generate negative class
+                if len(organelle_arrays) > 1:
+                    found_gt_config = ConcatArrayConfig(
+                        name=f"{dataset}_{current_class_name}_{self.output_resolution[0]}nm_gt",
+                        channels=list(organelle_arrays.keys()),
+                        source_array_configs=organelle_arrays,
+                    )
+                    missing_mask_config = LogicalOrArrayConfig(
+                        name=f"{dataset}_{current_class_name}_{self.output_resolution[0]}nm_labelled_voxels",
+                        source_array_config=found_gt_config,
+                    )
+                else:
+                    missing_mask_config = list(organelle_arrays.values())[0]
+                missing_gt_config = ConstantArrayConfig(
+                    name=f"{dataset}_{current_class_name}_{self.output_resolution[0]}nm_gt",
+                    source_array_config=list(organelle_arrays.values())[0],
+                    constant=0,
+                )
+                for t in missing_classes:
+                    target_images[t] = missing_gt_config
+                    target_masks[t] = missing_mask_config
+
+        for t in found_classes:
+            target_masks[t] = ConstantArrayConfig(
+                name=f"{dataset}_{t}_{self.output_resolution[0]}nm_labelled_voxels",
+                source_array_config=target_images[t],
+                constant=1,
+            )
+
+        gt_config = ConcatArrayConfig(
+            name=f"{dataset}_{targets_str}_{self.output_resolution[0]}nm_gt",
+            channels=[organelle for organelle in current_targets],
+            source_array_configs={k: target_images[k] for k in current_targets},
+        )
+        mask_config = ConcatArrayConfig(
+            name=f"{dataset}_{targets_str}_{self.output_resolution[0]}nm_mask",
+            channels=[organelle for organelle in current_targets],
+            source_array_configs={k: target_masks[k] for k in current_targets},
+        )
+
+        return raw_config, gt_config, mask_config
+
+    @staticmethod
+    def generate_from_csv(
+        csv_path: Path,
+        input_resolution: Union[Sequence[int], Coordinate],
+        output_resolution: Union[Sequence[int], Coordinate],
+        name: Optional[str] = None,
+        **kwargs,
+    ):
+        """
+        Generate the data split from the CSV file.
+
+        Args:
+            csv_path : obj
+                The CSV file path.
+            input_resolution : obj
+                The input resolution. Must contain integer values; non-integer
+                values will be truncated with a warning (see GitHub issue #296).
+            output_resolution : obj
+                The output resolution. Must contain integer values; non-integer
+                values will be truncated with a warning (see GitHub issue #296).
+            name : str
+                The name.
+            **kwargs : dict
+                The keyword arguments.
+        Returns:
+            obj : The data split.
+        Raises:
+            FileNotFoundError
+            If the file does not exist, a FileNotFoundError is raised.
+        Examples:
+            >>> generate_from_csv(csv_path, input_resolution, output_resolution, name, **kwargs)
+        Notes:
+            This function is used to generate the data split from the CSV file.
+
+        """
+        if isinstance(csv_path, str):
+            csv_path = Path(csv_path)
+
+        if name is None:
+            name = csv_path.stem
+
+        return DataSplitGenerator(
+            name,
+            generate_dataspec_from_csv(csv_path),
+            input_resolution,
+            output_resolution,
+            **kwargs,
+        )
+
+
+def format_class_name(class_name, separator_character="&", targets=None):
+    """
+    Format the class name.
+
+    Args:
+        class_name : obj
+            The class name.
+        separator_character : str
+            The separator character.
+    Returns:
+        obj : The class name.
+    Raises:
+        ValueError
+            If the class name is invalid, a ValueError is raised.
+    Examples:
+        >>> format_class_name(class_name, separator_character)
+    Notes:
+        This function is used to format the class name.
+    """
+    if "[" in class_name:
+        if "]" not in class_name:
+            raise ValueError(f"Invalid class name {class_name} missing ']'")
+        classes = class_name.split("[")[1].split("]")[0].split(separator_character)
+        base_class_name = class_name.split("[")[0]
+        return [f"{base_class_name}{c}" for c in classes], classes
+    else:
+        if targets is None:
+            raise ValueError(f"Invalid class name {class_name} missing '[' and ']'")
+        if len(targets) > 1:
+            raise ValueError(f"Invalid class name {class_name} missing '[' and ']'")
+        return [class_name], [targets[0]]

--- a/dacapo/experiments/run_config.py
+++ b/dacapo/experiments/run_config.py
@@ -495,10 +495,8 @@ class RunConfig:
                 summary = test_model(my_model_descr)
                 summary.display()
 
-            logger.info(
-                "package path:",
-                save_bioimageio_package(my_model_descr, output_path=path),
-            )
+            saved_path = save_bioimageio_package(my_model_descr, output_path=path)
+            logger.info(f"package path: {saved_path}")
 
     def data_loader(self) -> torch.utils.data.DataLoader:
         dataset = self.trainer.iterable_dataset(

--- a/dacapo/experiments/tasks/hot_distance_task.py
+++ b/dacapo/experiments/tasks/hot_distance_task.py
@@ -49,6 +49,8 @@ class HotDistanceTask(Task):
             scale_factor=task_config.scale_factor,
             mask_distances=task_config.mask_distances,
             kernel_size=task_config.kernel_size,
+            epsilon=task_config.epsilon,
+            threshold=task_config.threshold,
         )
         self.loss = HotDistanceLoss()
         self.post_processor = ThresholdPostProcessor()

--- a/dacapo/experiments/tasks/hot_distance_task_config.py
+++ b/dacapo/experiments/tasks/hot_distance_task_config.py
@@ -60,3 +60,22 @@ class HotDistanceTaskConfig(TaskConfig):
     kernel_size: int | None = attr.ib(
         default=None,
     )
+
+    epsilon: float = attr.ib(
+        default=5e-2,
+        metadata={
+            "help_text": "A small additive offset applied to the absolute distance when "
+            "computing the distance mask boundary. Prevents voxels exactly on the "
+            "theoretical boundary from being masked out due to floating-point equality. "
+            "Set to None to disable the offset."
+        },
+    )
+
+    threshold: float = attr.ib(
+        default=0.8,
+        metadata={
+            "help_text": "The upper clamp value when comparing abs(distance) + epsilon "
+            "against the boundary distance during distance mask creation. Voxels where "
+            "the clamped value exceeds the boundary distance are masked out."
+        },
+    )

--- a/dacapo/experiments/tasks/predictors/hot_distance_predictor.py
+++ b/dacapo/experiments/tasks/predictors/hot_distance_predictor.py
@@ -54,6 +54,8 @@ class HotDistancePredictor(Predictor):
         scale_factor: float,
         mask_distances: bool,
         kernel_size: int,
+        epsilon: float = 5e-2,
+        threshold: float = 0.8,
     ):
         """
         Initializes the HotDistancePredictor.
@@ -62,10 +64,17 @@ class HotDistancePredictor(Predictor):
             channels (List[str]): The list of class labels.
             scale_factor (float): The scale factor for the distance transform.
             mask_distances (bool): Whether to mask distances based on the distance to the boundary.
+            kernel_size (int): The kernel size for the convolutional head.
+            epsilon (float): Small offset added to abs(distance) when computing the
+                distance mask. Prevents boundary voxels from being masked due to
+                floating-point equality. Set to None to disable. Defaults to 5e-2.
+            threshold (float): Upper clamp value for the distance mask comparison.
+                Voxels where clip(abs(distance) + epsilon, 0, threshold) exceeds the
+                boundary distance are masked out. Defaults to 0.8.
         Raises:
             NotImplementedError: This method is not implemented.
         Examples:
-            >>> predictor = HotDistancePredictor(channels, scale_factor, mask_distances)
+            >>> predictor = HotDistancePredictor(channels, scale_factor, mask_distances, kernel_size)
         Note:
             The channels argument is a list of strings, each string is the name of a class that is being segmented.
         """
@@ -78,8 +87,8 @@ class HotDistancePredictor(Predictor):
         self.mask_distances = mask_distances
 
         self.max_distance = 1 * scale_factor
-        self.epsilon = 5e-2  # TODO: should be a config parameter
-        self.threshold = 0.8  # TODO: should be a config parameter
+        self.epsilon = epsilon
+        self.threshold = threshold
 
     @property
     def embedding_dims(self):

--- a/dacapo/predict.py
+++ b/dacapo/predict.py
@@ -147,7 +147,7 @@ def predict(
 
     # run blockwise prediction
     worker_file = str(Path(Path(dacapo.blockwise.__file__).parent, "predict_worker.py"))
-    logger.info("Running blockwise prediction with worker_file: ", worker_file)
+    logger.info(f"Running blockwise prediction with worker_file: {worker_file}")
     success = run_blockwise(
         worker_file=worker_file,
         total_roi=_input_roi,

--- a/references.md
+++ b/references.md
@@ -1,0 +1,79 @@
+# DaCapo Contribution References
+
+This file tracks bugs, issues, and solutions encountered and resolved in this project.
+
+---
+
+## Entry 1 — 2026-05-14
+
+### Issue Description
+`datasplit_generator.py` (containing the widely-used `DataSplitGenerator` class) was accidentally deleted in commit `f5c26fdb` ("avoid prints, replace with logger.info"). The commit was intended to replace `print()` calls with `logger.info()`, but instead deleted the entire 1073-line file. This broke all examples that import `DataSplitGenerator` from `dacapo.experiments.datasplits`.
+
+Additionally, `DataSplitGenerator` was never re-exported from the package `__init__.py`, so even if the file existed users could not import it via the documented API.
+
+**Related GitHub issues:** [#296 — Non-integer inputs in DataSplitGenerator](https://github.com/janelia-cellmap/dacapo/issues/296)
+
+### Root Cause Analysis
+The commit `f5c26fdb` (Feb 17, 2025) deleted `dacapo/experiments/datasplits/datasplit_generator.py` while it only needed to replace one `print()` call on line 88 with `logger.info()`. This appears to be an accidental deletion.
+
+The file also had a circular-import risk: it imported `TrainValidateDataSplitConfig` from `dacapo.experiments.datasplits` (the package), while now the package `__init__.py` would import from it.
+
+### Solution Applied
+1. Restored `datasplit_generator.py` from git history (pre-deletion state).
+2. Replaced the lone `print()` call in `resize_if_needed()` with `logger.info()`.
+3. Fixed the circular import by importing `TrainValidateDataSplitConfig` directly from its module file.
+4. Added `DataSplitGenerator` to `dacapo/experiments/datasplits/__init__.py`.
+5. Added a `_validate_resolution()` helper that warns when non-integer voxel resolutions are passed (addresses issue #296).
+
+### Changes Made
+| File | Change |
+|------|--------|
+| `dacapo/experiments/datasplits/datasplit_generator.py` | Restored; `print()` → `logger.info()`; fixed circular import; added non-integer resolution warning |
+| `dacapo/experiments/datasplits/__init__.py` | Added `from .datasplit_generator import DataSplitGenerator` |
+
+### Prevention Notes
+- When making style-only commits (print → logger), run `git diff --stat` before committing to verify no files are accidentally deleted.
+
+---
+
+## Entry 2 — 2026-05-14
+
+### Issue Description
+Two `logger.info()` calls had variables passed as separate positional arguments (mimicking `print()` syntax). Python's logging module silently ignores extra args when the message has no `%`-format specifiers, so the variable values were never logged.
+
+1. `dacapo/predict.py:150` — worker file path silently dropped.
+2. `dacapo/experiments/run_config.py:498-501` — saved BioImage.IO package path silently dropped.
+
+Both introduced in commit `f5c26fdb`.
+
+### Solution Applied
+Changed both to f-strings. For `run_config.py`, the `save_bioimageio_package()` return value is captured in a variable first so the side effect is explicit.
+
+### Changes Made
+| File | Change |
+|------|--------|
+| `dacapo/predict.py` | `logger.info("...", worker_file)` → `logger.info(f"...{worker_file}")` |
+| `dacapo/experiments/run_config.py` | Split into `saved_path = save_bioimageio_package(...)` + `logger.info(f"package path: {saved_path}")` |
+
+### Prevention Notes
+Always use f-strings when logging variables. Never pass extra positional args to `logger.*`.
+
+---
+
+## Entry 3 — 2026-05-14
+
+### Issue Description
+`HotDistancePredictor` had two hardcoded magic numbers — `epsilon = 5e-2` and `threshold = 0.8` — marked with `# TODO: should be a config parameter`. Users had no way to tune them without modifying source code.
+
+### Solution Applied
+Added `epsilon` and `threshold` as optional `attr.ib` fields to `HotDistanceTaskConfig` with the existing defaults (fully backward-compatible), wired through `HotDistanceTask` to `HotDistancePredictor`.
+
+### Changes Made
+| File | Change |
+|------|--------|
+| `dacapo/experiments/tasks/hot_distance_task_config.py` | Added `epsilon` and `threshold` attr fields |
+| `dacapo/experiments/tasks/hot_distance_task.py` | Forwarded both values to `HotDistancePredictor` |
+| `dacapo/experiments/tasks/predictors/hot_distance_predictor.py` | Replaced hardcoded values with constructor params |
+
+### Prevention Notes
+Avoid hardcoding tunable hyperparameters in predictor classes. Always expose them through the config from the start.


### PR DESCRIPTION
## Summary

- **Restores `DataSplitGenerator`** — the entire `datasplit_generator.py` (1073 lines) was accidentally deleted in commit `f5c26fdb` (\"avoid prints, replace with logger.info\"). This broke every example in the repo that imports `DataSplitGenerator`. The file is restored with the original `print()` replaced by `logger.info()` as the commit intended.
- **Exports `DataSplitGenerator` from the package** — adds `from .datasplit_generator import DataSplitGenerator` to `dacapo/experiments/datasplits/__init__.py` so it's importable via the documented public API.
- **Fixes non-integer resolution warning (closes #296)** — adds a `_validate_resolution()` helper that emits a `logger.warning()` when float voxel resolutions are passed, explaining the silent truncation and pointing users to issue #296.
- **Fixes two broken `logger.info()` calls** (also introduced in `f5c26fdb`):
  - `dacapo/predict.py` — worker file path was silently dropped from the log.
  - `dacapo/experiments/run_config.py` — saved BioImage.IO package path was silently dropped; also separates the `save_bioimageio_package()` call from the log statement for clarity.
- **Promotes `epsilon` and `threshold` to config fields on `HotDistanceTaskConfig`** — resolves two `# TODO: should be a config parameter` comments in `hot_distance_predictor.py`. Defaults are unchanged so existing configs remain fully backward-compatible.

## Test plan

- [ ] Verify `from dacapo.experiments.datasplits import DataSplitGenerator` no longer raises `ImportError`
- [ ] Verify examples in `examples/distance_task/` and `examples/cosem/` can be imported without error
- [ ] Confirm a `logger.warning` is emitted when passing float resolutions (e.g. `Coordinate(9.8, 9.8, 25)`) to `DataSplitGenerator`
- [ ] Confirm `HotDistanceTaskConfig` accepts `epsilon` and `threshold` keyword arguments and they are forwarded correctly to the predictor
- [ ] Run existing test suite: `pytest tests/`

Made with [Cursor](https://cursor.com)